### PR TITLE
Allow using multiple attributes to extract html files.

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -105,8 +105,9 @@ var Extractor = (function () {
         this.options.attributes.unshift(this.options.attribute);
 
         this.strings = {};
-        this.attrRegex = mkAttrRegex(this.options.startDelim, this.options.endDelim, this.options.attribute);
-        this.noDelimRegex = mkAttrRegex('', '', this.options.attribute);
+        const keyWords = '(' + this.options.attributes.join('|') + ')';
+        this.attrRegex = mkAttrRegex(this.options.startDelim, this.options.endDelim, keyWords);
+        this.noDelimRegex = mkAttrRegex('', '', keyWords);
     }
 
     Extractor.isValidStrategy = function (strategy) {


### PR DESCRIPTION
### Summary
I've created a 'bwtranslate' filter, in addition to 'translate' filter, to extract html. The current library creates keyword regex with `this.options.attribute`, which is hardcoded to `translate`.

### Proposed Sol
Here, I've created `keyWords` as the aggregates of attributes in the form of Regex OR. 
e.g.
`this.options.attributes = ['translate', 'bwtranlsate']`
`keyWords == '(translate|bwtranslate)'`

This allows for us to extract both attributes of `translate` and `bwtranslate` in html.

### Repro
in GruntFile.js:
```
    nggettext_extract: {
      all: {
        options: {
          'markerNames': ['L', 'L_NOOP'],
          'attributes': ['bwtranslate'],
```
In terminal:
run `./l10n.sh frontend`
* we should capture all the attributes:
`<span translate> text </span>`
`<span bwtranslate> text </span>`
`<span uibtooltip="{ 'text' | translate}></span>"`
`<span uibtooltip="{ 'text' | bwtranslate}></span>"`
